### PR TITLE
qSlicerAstroWelcomeModuleWidget: Use releaseType() instead of isRelease()

### DIFF
--- a/SlicerAstroWelcome/qSlicerAstroWelcomeModuleWidget.cxx
+++ b/SlicerAstroWelcome/qSlicerAstroWelcomeModuleWidget.cxx
@@ -206,7 +206,7 @@ void qSlicerAstroWelcomeModuleWidget::loadSource(QWidget* widget)
 
     // Update occurences of wiki URLs
     QString wikiVersion = "Nightly";
-    if (app->isRelease())
+    if (app->releaseType() == "Stable")
       {
       wikiVersion = QString("%1.%2").arg(app->majorVersion()).arg(app->minorVersion());
       }


### PR DESCRIPTION
See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/Slicer#Slicer_4.8:_Application:_isRelease.28.29_function_not_available_or_deprecated